### PR TITLE
Disable Ollama by default and gate via settings

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4347,15 +4347,18 @@ Please provide a JSON response with this exact structure:
     try {
       const { url, model } = req.body;
       
-      if (!url || !model) {
-        return res.status(400).json({ 
-          success: false, 
-          error: "URL and model are required" 
-        });
-      }
-      
-      const result = await aiService.testOllamaConnection(url, model);
-      res.json(result);
+    if (!url || !model) {
+      return res.status(400).json({
+        success: false,
+        error: "URL and model are required"
+      });
+    }
+
+    const result = await aiService.testOllamaConnection(url, model);
+    if (result.success) {
+      aiService.enableOllama(url, model);
+    }
+    res.json(result);
     } catch (error) {
       console.error("Ollama test error:", error);
       res.status(500).json({ 
@@ -4372,8 +4375,22 @@ Please provide a JSON response with this exact structure:
       res.json(status);
     } catch (error) {
       console.error("Ollama status error:", error);
-      res.status(500).json({ 
-        error: error instanceof Error ? error.message : "Unknown error" 
+      res.status(500).json({
+        error: error instanceof Error ? error.message : "Unknown error"
+      });
+    }
+  });
+
+  // Disable Ollama integration
+  app.post("/api/ai/ollama/disable", async (req, res) => {
+    try {
+      aiService.disableOllama();
+      res.json({ success: true });
+    } catch (error) {
+      console.error("Ollama disable error:", error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error"
       });
     }
   });
@@ -4421,9 +4438,7 @@ Please provide a JSON response with this exact structure:
       }
 
       // Update AI service status to reflect shutdown
-      if (aiService.updateOllamaStatus) {
-        aiService.updateOllamaStatus('disconnected');
-      }
+      aiService.disableOllama();
 
       res.json({
         success: shutdownResult.success,
@@ -4556,17 +4571,17 @@ Please provide a JSON response with this exact structure:
       const { url, model } = req.body;
       
       if (!url || !model) {
-        return res.status(400).json({ 
-          error: "URL and model are required" 
+        return res.status(400).json({
+          error: "URL and model are required"
         });
       }
-      
-      aiService.updateOllamaConfig(url, model);
+
+      aiService.enableOllama(url, model);
       res.json({ success: true });
     } catch (error) {
       console.error("Ollama config update error:", error);
-      res.status(500).json({ 
-        error: error instanceof Error ? error.message : "Unknown error" 
+      res.status(500).json({
+        error: error instanceof Error ? error.message : "Unknown error"
       });
     }
   });
@@ -4737,30 +4752,6 @@ Make sure to include realistic, working code for the starter files that follows 
       res.status(500).json({ 
         error: "Project creation failed", 
         details: error instanceof Error ? error.message : "Unknown error" 
-      });
-    }
-  });
-
-  // Test Ollama connection endpoint
-  app.post("/api/ai/test-ollama", async (req, res) => {
-    try {
-      const { url, model } = req.body;
-      
-      if (!url || !model) {
-        return res.status(400).json({ 
-          success: false, 
-          error: "URL and model are required" 
-        });
-      }
-
-      const result = await aiService.testOllamaConnection(url, model);
-      res.json(result);
-      
-    } catch (error) {
-      console.error("❌ Error testing Ollama connection:", error);
-      res.json({ 
-        success: false, 
-        error: error instanceof Error ? error.message : "Unknown error" 
       });
     }
   });

--- a/server/services/ai.ts
+++ b/server/services/ai.ts
@@ -21,22 +21,24 @@ export class AIService {
   };
 
   private ollamaHealthCheck: NodeJS.Timeout | null = null;
-  private ollamaStatus: 'unknown' | 'connected' | 'disconnected' = 'unknown';
+  private ollamaStatus: 'unknown' | 'connected' | 'disconnected' | 'disabled' = 'disabled';
 
   constructor() {
-    // Start health monitoring if Ollama is configured
-    this.startOllamaHealthMonitoring();
+    // Ollama is disabled by default. Health monitoring will only start when
+    // explicitly enabled through settings.
   }
 
   private startOllamaHealthMonitoring() {
+    if (this.ollamaHealthCheck) return;
+
     let failureCount = 0;
     const maxFailures = 3;
-    
+
     // Check every 30 seconds with exponential backoff on failures
     this.ollamaHealthCheck = setInterval(async () => {
       try {
         const result = await this.testOllamaConnection(this.ollamaConfig.url, this.ollamaConfig.model);
-        
+
         if (result.success) {
           if (this.ollamaStatus !== 'connected') {
             this.ollamaStatus = 'connected';
@@ -45,7 +47,7 @@ export class AIService {
           }
         } else {
           failureCount++;
-          
+
           // Only mark as disconnected after multiple failures to avoid false positives
           if (failureCount >= maxFailures && this.ollamaStatus !== 'disconnected') {
             this.ollamaStatus = 'disconnected';
@@ -65,12 +67,21 @@ export class AIService {
     }, 30000); // 30 seconds
   }
 
-  updateOllamaConfig(url: string, model: string) {
-    this.ollamaConfig.url = url;
-    this.ollamaConfig.model = model;
-    // Reset status to trigger fresh health check
+  enableOllama(url?: string, model?: string) {
+    if (url) this.ollamaConfig.url = url;
+    if (model) this.ollamaConfig.model = model;
     this.ollamaStatus = 'unknown';
-    logger.ollama(`Configuration updated: ${url} with model ${model}`);
+    this.startOllamaHealthMonitoring();
+    logger.ollama('Ollama integration enabled');
+  }
+
+  disableOllama() {
+    if (this.ollamaHealthCheck) {
+      clearInterval(this.ollamaHealthCheck);
+      this.ollamaHealthCheck = null;
+    }
+    this.ollamaStatus = 'disabled';
+    logger.ollama('Ollama integration disabled');
   }
 
   getOllamaStatus() {


### PR DESCRIPTION
## Summary
- Disable Ollama health checks by default and add explicit enable/disable controls
- Expose API endpoints to toggle Ollama and adjust config
- Reflect disabled state in settings UI and allow turning off integration
- Remove duplicate test endpoint and streamline enable flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: 'db' is possibly 'null' in server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a37a8771088325944b693ca554c5a0