### PR TITLE
Add robust readFile tool for developer agent

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3969,7 +3969,7 @@ Please provide a JSON response with this exact structure:
   });
 
   // Developer Agent - AI-powered code assistant
-  const { readFile, writeFile, mkdir, rename } = await import('fs/promises');
+  const { readFile: fsReadFile, writeFile, mkdir, rename } = await import('fs/promises');
   const path = await import('path');
   const { spawn } = await import('child_process');
   
@@ -3985,9 +3985,11 @@ Please provide a JSON response with this exact structure:
 
   // Developer Agent tools
   const agentTools = {
-    readFile: async ({ filepath }: { filepath: string }) => {
-      const fullPath = safePath(filepath);
-      return await readFile(fullPath, 'utf8');
+    readFile: async ({ filepath, path: altPath }: { filepath?: string, path?: string }) => {
+      const target = filepath || altPath;
+      if (!target) throw new Error('filepath is required');
+      const fullPath = safePath(target);
+      return await fsReadFile(fullPath, 'utf8');
     },
     writeFile: async ({ filepath, content }: { filepath: string, content: string }) => {
       const fullPath = safePath(filepath);
@@ -4036,6 +4038,86 @@ Please provide a JSON response with this exact structure:
     },
   };
 
+  const toolDefs = [
+    {
+      type: 'function' as const,
+      function: {
+        name: 'readFile',
+        description: 'Read file contents',
+        parameters: {
+          type: 'object',
+          properties: {
+            filepath: { type: 'string', description: 'Path to file to read' }
+          },
+          required: ['filepath']
+        }
+      }
+    },
+    {
+      type: 'function' as const,
+      function: {
+        name: 'writeFile',
+        description: 'Write content to a file',
+        parameters: {
+          type: 'object',
+          properties: {
+            filepath: { type: 'string', description: 'Path to file to write' },
+            content: { type: 'string', description: 'Content to write' }
+          },
+          required: ['filepath', 'content']
+        }
+      }
+    },
+    {
+      type: 'function' as const,
+      function: {
+        name: 'mkdir',
+        description: 'Create a directory',
+        parameters: {
+          type: 'object',
+          properties: {
+            dirpath: { type: 'string', description: 'Directory path to create' }
+          },
+          required: ['dirpath']
+        }
+      }
+    },
+    {
+      type: 'function' as const,
+      function: {
+        name: 'move',
+        description: 'Move or rename a file',
+        parameters: {
+          type: 'object',
+          properties: {
+            from: { type: 'string', description: 'Source path' },
+            to: { type: 'string', description: 'Destination path' }
+          },
+          required: ['from', 'to']
+        }
+      }
+    },
+    {
+      type: 'function' as const,
+      function: {
+        name: 'run',
+        description: 'Execute a shell command',
+        parameters: {
+          type: 'object',
+          properties: {
+            cmd: { type: 'string', description: 'Command to run' },
+            args: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Command arguments'
+            }
+          },
+          required: ['cmd']
+        }
+      }
+    }
+  ];
+
   // Developer Agent endpoint
   app.post('/api/agent', async (req, res) => {
     try {
@@ -4053,19 +4135,6 @@ Please provide a JSON response with this exact structure:
       const openai = new OpenAI({
         apiKey: process.env.OPENAI_API_KEY,
       });
-
-      const toolDefs = Object.keys(agentTools).map(name => ({
-        type: 'function' as const,
-        function: { 
-          name, 
-          description: `Tool: ${name}`,
-          parameters: { 
-            type: 'object', 
-            properties: {}, 
-            additionalProperties: true 
-          } 
-        }
-      }));
 
       let history = messages;
       
@@ -4156,19 +4225,6 @@ Please provide a JSON response with this exact structure:
       const openai = new OpenAI({
         apiKey: process.env.OPENAI_API_KEY,
       });
-
-      const toolDefs = Object.keys(agentTools).map(name => ({
-        type: 'function' as const,
-        function: { 
-          name, 
-          description: `Tool: ${name}`,
-          parameters: { 
-            type: 'object', 
-            properties: {}, 
-            additionalProperties: true 
-          } 
-        }
-      }));
 
       let history = messages;
       let finalResponse = '';


### PR DESCRIPTION
## Summary
- Allow developer agent to read files with path validation and optional argument names
- Define explicit tool schemas so the agent passes required parameters

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: TypeScript errors in unrelated files)

------
https://chatgpt.com/codex/tasks/task_e_68a408dc06d0832594cf8c0906988bad