### PR TITLE
Add file listing tool for developer agent

### DIFF
--- a/dev-agent-server/src/index.ts
+++ b/dev-agent-server/src/index.ts
@@ -1,12 +1,12 @@
 import 'dotenv/config'
 import express from 'express'
-import { readFile, writeFile, mkdir, rename } from 'node:fs/promises'
+import { readFile as fsReadFile, writeFile, mkdir, rename, readdir } from 'node:fs/promises'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
 import OpenAI from 'openai'
 
 const app = express()
-app.use(express.json({ limit: '2mb' }))
+app.use(express.json({ limit: '5mb' }))
 
 const PORT = Number(process.env.PORT || 8787)
 const ROOT = path.resolve(process.env.AGENT_ROOT ?? process.cwd())
@@ -115,8 +115,27 @@ app.post('/api/ai-chats/:chatId/stream', async (req, res) => {
 
 /* -------- Developer Agent (tool-calling) -------- */
 const tools = {
-  readFile: async ({ filepath }: { filepath: string }) => {
-    return await readFile(safe(filepath), 'utf8')
+  readFile: async ({ filepath, path: altPath }: { filepath?: string, path?: string }) => {
+    const target = filepath || altPath
+    if (!target) throw new Error('filepath is required')
+    return await fsReadFile(safe(target), 'utf8')
+  },
+  listFiles: async ({ dirpath = '.', ext }: { dirpath?: string, ext?: string }) => {
+    const dir = safe(dirpath)
+    const out: string[] = []
+    async function walk(d: string) {
+      const entries = await readdir(d, { withFileTypes: true })
+      for (const entry of entries) {
+        const full = path.join(d, entry.name)
+        if (entry.isDirectory()) {
+          await walk(full)
+        } else if (!ext || entry.name.endsWith(ext)) {
+          out.push(path.relative(ROOT, full))
+        }
+      }
+    }
+    await walk(dir)
+    return out
   },
   writeFile: async ({ filepath, content }: { filepath: string, content: string }) => {
     const full = safe(filepath)
@@ -143,10 +162,99 @@ const tools = {
 
 app.post('/api/agent', async (req, res) => {
   const { messages, model } = req.body as { messages: any[], model?: string }
-  const toolDefs = Object.keys(tools).map(name => ({
+const toolDefs = [
+  {
     type: 'function' as const,
-    function: { name, description: `Tool: ${name}`, parameters: { type: 'object', properties: {}, additionalProperties: true } }
-  }))
+    function: {
+      name: 'readFile',
+      description: 'Read file contents',
+      parameters: {
+        type: 'object',
+        properties: {
+          filepath: { type: 'string', description: 'Path to file to read' }
+        },
+        required: ['filepath']
+      }
+    }
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'listFiles',
+      description: 'List files in a directory',
+      parameters: {
+        type: 'object',
+        properties: {
+          dirpath: { type: 'string', description: 'Directory to list', default: '.' },
+          ext: { type: 'string', description: 'Optional file extension filter (e.g. .tsx)' }
+        }
+      }
+    }
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'writeFile',
+      description: 'Write content to a file',
+      parameters: {
+        type: 'object',
+        properties: {
+          filepath: { type: 'string', description: 'Path to file to write' },
+          content: { type: 'string', description: 'Content to write' }
+        },
+        required: ['filepath', 'content']
+      }
+    }
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'mkdir',
+      description: 'Create a directory',
+      parameters: {
+        type: 'object',
+        properties: {
+          dirpath: { type: 'string', description: 'Directory path to create' }
+        },
+        required: ['dirpath']
+      }
+    }
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'move',
+      description: 'Move or rename a file',
+      parameters: {
+        type: 'object',
+        properties: {
+          from: { type: 'string', description: 'Source path' },
+          to: { type: 'string', description: 'Destination path' }
+        },
+        required: ['from', 'to']
+      }
+    }
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'run',
+      description: 'Execute a shell command',
+      parameters: {
+        type: 'object',
+        properties: {
+          cmd: { type: 'string', description: 'Command to run' },
+          args: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Command arguments'
+          }
+        },
+        required: ['cmd']
+      }
+    }
+  }
+]
 
   let history = messages
   for (let i = 0; i < 8; i++) {

--- a/dev-agent-server/src/index.ts
+++ b/dev-agent-server/src/index.ts
@@ -171,9 +171,9 @@ const toolDefs = [
       parameters: {
         type: 'object',
         properties: {
-          filepath: { type: 'string', description: 'Path to file to read' }
-        },
-        required: ['filepath']
+          filepath: { type: 'string', description: 'Path to file to read' },
+          path: { type: 'string', description: 'Alias for filepath' }
+        }
       }
     }
   },

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4064,9 +4064,9 @@ Please provide a JSON response with this exact structure:
         parameters: {
           type: 'object',
           properties: {
-            filepath: { type: 'string', description: 'Path to file to read' }
-          },
-          required: ['filepath']
+            filepath: { type: 'string', description: 'Path to file to read' },
+            path: { type: 'string', description: 'Alias for filepath' }
+          }
         }
       }
     },

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3969,7 +3969,7 @@ Please provide a JSON response with this exact structure:
   });
 
   // Developer Agent - AI-powered code assistant
-  const { readFile, writeFile, mkdir, rename } = await import('fs/promises');
+  const { readFile: fsReadFile, writeFile, mkdir, rename, readdir } = await import('fs/promises');
   const path = await import('path');
   const { spawn } = await import('child_process');
   
@@ -3985,9 +3985,28 @@ Please provide a JSON response with this exact structure:
 
   // Developer Agent tools
   const agentTools = {
-    readFile: async ({ filepath }: { filepath: string }) => {
-      const fullPath = safePath(filepath);
-      return await readFile(fullPath, 'utf8');
+    readFile: async ({ filepath, path: altPath }: { filepath?: string, path?: string }) => {
+      const target = filepath || altPath;
+      if (!target) throw new Error('filepath is required');
+      const fullPath = safePath(target);
+      return await fsReadFile(fullPath, 'utf8');
+    },
+    listFiles: async ({ dirpath = '.', ext }: { dirpath?: string, ext?: string }) => {
+      const dir = safePath(dirpath);
+      const files: string[] = [];
+      async function walk(d: string) {
+        const entries = await readdir(d, { withFileTypes: true });
+        for (const entry of entries) {
+          const full = path.join(d, entry.name);
+          if (entry.isDirectory()) {
+            await walk(full);
+          } else if (!ext || entry.name.endsWith(ext)) {
+            files.push(path.relative(process.cwd(), full));
+          }
+        }
+      }
+      await walk(dir);
+      return files;
     },
     writeFile: async ({ filepath, content }: { filepath: string, content: string }) => {
       const fullPath = safePath(filepath);
@@ -4036,6 +4055,100 @@ Please provide a JSON response with this exact structure:
     },
   };
 
+  const toolDefs = [
+    {
+      type: 'function' as const,
+      function: {
+        name: 'readFile',
+        description: 'Read file contents',
+        parameters: {
+          type: 'object',
+          properties: {
+            filepath: { type: 'string', description: 'Path to file to read' }
+          },
+          required: ['filepath']
+        }
+      }
+    },
+    {
+      type: 'function' as const,
+      function: {
+        name: 'listFiles',
+        description: 'List files in a directory',
+        parameters: {
+          type: 'object',
+          properties: {
+            dirpath: { type: 'string', description: 'Directory to list', default: '.' },
+            ext: { type: 'string', description: 'Optional file extension filter (e.g. .tsx)' }
+          }
+        }
+      }
+    },
+    {
+      type: 'function' as const,
+      function: {
+        name: 'writeFile',
+        description: 'Write content to a file',
+        parameters: {
+          type: 'object',
+          properties: {
+            filepath: { type: 'string', description: 'Path to file to write' },
+            content: { type: 'string', description: 'Content to write' }
+          },
+          required: ['filepath', 'content']
+        }
+      }
+    },
+    {
+      type: 'function' as const,
+      function: {
+        name: 'mkdir',
+        description: 'Create a directory',
+        parameters: {
+          type: 'object',
+          properties: {
+            dirpath: { type: 'string', description: 'Directory path to create' }
+          },
+          required: ['dirpath']
+        }
+      }
+    },
+    {
+      type: 'function' as const,
+      function: {
+        name: 'move',
+        description: 'Move or rename a file',
+        parameters: {
+          type: 'object',
+          properties: {
+            from: { type: 'string', description: 'Source path' },
+            to: { type: 'string', description: 'Destination path' }
+          },
+          required: ['from', 'to']
+        }
+      }
+    },
+    {
+      type: 'function' as const,
+      function: {
+        name: 'run',
+        description: 'Execute a shell command',
+        parameters: {
+          type: 'object',
+          properties: {
+            cmd: { type: 'string', description: 'Command to run' },
+            args: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Command arguments'
+            }
+          },
+          required: ['cmd']
+        }
+      }
+    }
+  ];
+
   // Developer Agent endpoint
   app.post('/api/agent', async (req, res) => {
     try {
@@ -4053,19 +4166,6 @@ Please provide a JSON response with this exact structure:
       const openai = new OpenAI({
         apiKey: process.env.OPENAI_API_KEY,
       });
-
-      const toolDefs = Object.keys(agentTools).map(name => ({
-        type: 'function' as const,
-        function: { 
-          name, 
-          description: `Tool: ${name}`,
-          parameters: { 
-            type: 'object', 
-            properties: {}, 
-            additionalProperties: true 
-          } 
-        }
-      }));
 
       let history = messages;
       
@@ -4156,19 +4256,6 @@ Please provide a JSON response with this exact structure:
       const openai = new OpenAI({
         apiKey: process.env.OPENAI_API_KEY,
       });
-
-      const toolDefs = Object.keys(agentTools).map(name => ({
-        type: 'function' as const,
-        function: { 
-          name, 
-          description: `Tool: ${name}`,
-          parameters: { 
-            type: 'object', 
-            properties: {}, 
-            additionalProperties: true 
-          } 
-        }
-      }));
 
       let history = messages;
       let finalResponse = '';


### PR DESCRIPTION
## Summary
- Enable developer agent to list project files with optional extension filter
- Clear AI chat message box after sending and allow larger payloads

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: TypeScript errors in server and client files)


------
https://chatgpt.com/codex/tasks/task_e_68a408dc06d0832594cf8c0906988bad