### PR TITLE
refactor: centralize agent tools

### DIFF
--- a/dev-agent-server/src/index.ts
+++ b/dev-agent-server/src/index.ts
@@ -1,15 +1,12 @@
 import 'dotenv/config'
 import express from 'express'
-import { readFile as fsReadFile, writeFile, mkdir, rename } from 'node:fs/promises'
-import path from 'node:path'
-import { spawn } from 'node:child_process'
+import { tools as agentTools, toolDefs } from '../../shared/agentTools'
 import OpenAI from 'openai'
 
 const app = express()
 app.use(express.json({ limit: '2mb' }))
 
 const PORT = Number(process.env.PORT || 8787)
-const ROOT = path.resolve(process.env.AGENT_ROOT ?? process.cwd())
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
@@ -21,11 +18,6 @@ const projectChats = new Map<string, Msg[]>()
 const chatById = new Map<string, Msg[]>()
 const uuid = () => Math.random().toString(36).slice(2) + Date.now().toString(36)
 
-function safe(p: string) {
-  const full = path.resolve(ROOT, p)
-  if (!full.startsWith(ROOT)) throw new Error('Path outside sandbox')
-  return full
-}
 
 async function complete(messages: {role:'user'|'assistant'|'system', content:string}[], model?: string) {
   const m = model || process.env.MODEL || 'gpt-4o-mini'
@@ -114,116 +106,8 @@ app.post('/api/ai-chats/:chatId/stream', async (req, res) => {
 })
 
 /* -------- Developer Agent (tool-calling) -------- */
-const tools = {
-  readFile: async ({ filepath, path: altPath }: { filepath?: string, path?: string }) => {
-    const target = filepath || altPath
-    if (!target) throw new Error('filepath is required')
-    return await fsReadFile(safe(target), 'utf8')
-  },
-  writeFile: async ({ filepath, content }: { filepath: string, content: string }) => {
-    const full = safe(filepath)
-    await mkdir(path.dirname(full), { recursive: true })
-    await writeFile(full, content, 'utf8')
-    return 'ok'
-  },
-  mkdir: async ({ dirpath }: { dirpath: string }) => {
-    await mkdir(safe(dirpath), { recursive: true })
-    return 'ok'
-  },
-  move: async ({ from, to }: { from: string, to: string }) => {
-    await rename(safe(from), safe(to)); return 'ok'
-  },
-  run: async ({ cmd, args = [] }: { cmd: string, args?: string[] }) =>
-    new Promise((resolve) => {
-      const child = spawn(cmd, args, { cwd: ROOT, shell: true })
-      let out = ''; let err = ''
-      child.stdout.on('data', d => out += d)
-      child.stderr.on('data', d => err += d)
-      child.on('close', code => resolve({ code, out, err }))
-    }),
-}
-
 app.post('/api/agent', async (req, res) => {
   const { messages, model } = req.body as { messages: any[], model?: string }
-const toolDefs = [
-  {
-    type: 'function' as const,
-    function: {
-      name: 'readFile',
-      description: 'Read file contents',
-      parameters: {
-        type: 'object',
-        properties: {
-          filepath: { type: 'string', description: 'Path to file to read' }
-        },
-        required: ['filepath']
-      }
-    }
-  },
-  {
-    type: 'function' as const,
-    function: {
-      name: 'writeFile',
-      description: 'Write content to a file',
-      parameters: {
-        type: 'object',
-        properties: {
-          filepath: { type: 'string', description: 'Path to file to write' },
-          content: { type: 'string', description: 'Content to write' }
-        },
-        required: ['filepath', 'content']
-      }
-    }
-  },
-  {
-    type: 'function' as const,
-    function: {
-      name: 'mkdir',
-      description: 'Create a directory',
-      parameters: {
-        type: 'object',
-        properties: {
-          dirpath: { type: 'string', description: 'Directory path to create' }
-        },
-        required: ['dirpath']
-      }
-    }
-  },
-  {
-    type: 'function' as const,
-    function: {
-      name: 'move',
-      description: 'Move or rename a file',
-      parameters: {
-        type: 'object',
-        properties: {
-          from: { type: 'string', description: 'Source path' },
-          to: { type: 'string', description: 'Destination path' }
-        },
-        required: ['from', 'to']
-      }
-    }
-  },
-  {
-    type: 'function' as const,
-    function: {
-      name: 'run',
-      description: 'Execute a shell command',
-      parameters: {
-        type: 'object',
-        properties: {
-          cmd: { type: 'string', description: 'Command to run' },
-          args: {
-            type: 'array',
-            items: { type: 'string' },
-            description: 'Command arguments'
-          }
-        },
-        required: ['cmd']
-      }
-    }
-  }
-]
 
   let history = messages
   for (let i = 0; i < 8; i++) {
@@ -240,7 +124,7 @@ const toolDefs = [
     try {
       const args = call.function.arguments ? JSON.parse(call.function.arguments) : {}
       // @ts-ignore
-      result = await tools[call.function.name](args)
+      result = await agentTools[call.function.name](args)
     } catch (e:any) {
       result = { error: e.message ?? String(e) }
     }
@@ -252,5 +136,5 @@ const toolDefs = [
 app.get('/api/health', (_req, res) => res.json({ ok: true }))
 
 app.listen(PORT, () => {
-  console.log(`Dev Agent server running on :${PORT}, root: ${ROOT}`)
+  console.log(`Dev Agent server running on :${PORT}`)
 })

--- a/shared/agentTools.ts
+++ b/shared/agentTools.ts
@@ -1,0 +1,148 @@
+import { readFile as fsReadFile, writeFile as fsWriteFile, mkdir as fsMkdir, rename as fsRename, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const ROOT = path.resolve(process.env.AGENT_ROOT ?? process.cwd());
+
+function safe(p: string) {
+  const full = path.resolve(ROOT, p);
+  if (!full.startsWith(ROOT)) throw new Error('Path outside sandbox');
+  return full;
+}
+
+export async function readFile({ filepath, path: altPath }: { filepath?: string, path?: string }) {
+  const target = filepath || altPath;
+  if (!target) throw new Error('filepath is required');
+  return await fsReadFile(safe(target), 'utf8');
+}
+
+export async function listFiles({ dirpath }: { dirpath: string }) {
+  const full = safe(dirpath);
+  const entries = await readdir(full, { withFileTypes: true });
+  return entries.map(e => e.name);
+}
+
+export async function writeFile({ filepath, content }: { filepath: string, content: string }) {
+  const full = safe(filepath);
+  await fsMkdir(path.dirname(full), { recursive: true });
+  await fsWriteFile(full, content, 'utf8');
+  return 'ok';
+}
+
+export async function mkdir({ dirpath }: { dirpath: string }) {
+  await fsMkdir(safe(dirpath), { recursive: true });
+  return 'ok';
+}
+
+export async function move({ from, to }: { from: string, to: string }) {
+  await fsRename(safe(from), safe(to));
+  return 'ok';
+}
+
+export async function run({ cmd, args = [] }: { cmd: string, args?: string[] }) {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { cwd: ROOT, shell: true, stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = ''; let stderr = '';
+    child.stdout?.on('data', d => stdout += d.toString());
+    child.stderr?.on('data', d => stderr += d.toString());
+    child.on('close', code => resolve({ code, stdout, stderr }));
+    child.on('error', err => resolve({ code: -1, stdout: '', stderr: (err as any).message }));
+  });
+}
+
+export const tools = { readFile, listFiles, writeFile, mkdir, move, run } as const;
+
+export const toolDefs = [
+  {
+    type: 'function' as const,
+    function: {
+      name: 'readFile',
+      description: 'Read file contents',
+      parameters: {
+        type: 'object',
+        properties: {
+          filepath: { type: 'string', description: 'Path to file to read' }
+        },
+        required: ['filepath']
+      }
+    }
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'listFiles',
+      description: 'List files in a directory',
+      parameters: {
+        type: 'object',
+        properties: {
+          dirpath: { type: 'string', description: 'Directory path to list' }
+        },
+        required: ['dirpath']
+      }
+    }
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'writeFile',
+      description: 'Write content to a file',
+      parameters: {
+        type: 'object',
+        properties: {
+          filepath: { type: 'string', description: 'Path to file to write' },
+          content: { type: 'string', description: 'Content to write' }
+        },
+        required: ['filepath', 'content']
+      }
+    }
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'mkdir',
+      description: 'Create a directory',
+      parameters: {
+        type: 'object',
+        properties: {
+          dirpath: { type: 'string', description: 'Directory path to create' }
+        },
+        required: ['dirpath']
+      }
+    }
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'move',
+      description: 'Move or rename a file',
+      parameters: {
+        type: 'object',
+        properties: {
+          from: { type: 'string', description: 'Source path' },
+          to: { type: 'string', description: 'Destination path' }
+        },
+        required: ['from', 'to']
+      }
+    }
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'run',
+      description: 'Execute a shell command',
+      parameters: {
+        type: 'object',
+        properties: {
+          cmd: { type: 'string', description: 'Command to run' },
+          args: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Command arguments'
+          }
+        },
+        required: ['cmd']
+      }
+    }
+  }
+] as const;
+


### PR DESCRIPTION
## Summary
- add shared agentTools module with file system and exec helpers
- reuse shared agent tools in dev-agent server
- reuse shared agent tools in server routes to remove duplication

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d3a7abd48325ac3a5f3a4e8a662d